### PR TITLE
Update about.html

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -63,7 +63,7 @@ About
                         </div>
                         <strong>Copyright &copy;
                             <script>document.write(new Date().getFullYear())</script>
-                            <a href="https://github.com/ngoduykhanh/wireguard-ui">Wireguard UI</a>.
+                            <a href="https://github.com/ngoduykhanh/wireguard-ui" target="_blank">Wireguard UI</a>.
                         </strong> All rights reserved.
 
                     </div>


### PR DESCRIPTION
Add a target="_blank" to the github link to open it in a new tab (or window) instead of replacing the current Wireguard UI about page.